### PR TITLE
fix: remove legacy type hint in models

### DIFF
--- a/backend/tests/models/test_city.py
+++ b/backend/tests/models/test_city.py
@@ -1,5 +1,7 @@
 from bamboo.database import db, models
 
+from .utils import query_count
+
 
 def test_city_staff():
     site = models.Site(name="Test site", config={})
@@ -9,15 +11,15 @@ def test_city_staff():
     city.staffs.add(models.Staff(staff=user, category="supporter"))
     db.session.add_all([city])
     db.session.commit()
-    staffs = models.Staff.query.filter_by(city=city).all()
+    staffs = db.session.scalars(db.select(models.Staff).filter_by(city=city)).all()
     assert len(staffs) == 1
     assert staffs[0].staff == user
     assert staffs[0].city == city
 
     db.session.delete(city)
     db.session.commit()
-    assert models.Staff.query.count() == 0
-    assert models.User.query.count() == 1
+    assert query_count(models.Staff) == 0
+    assert query_count(models.User) == 1
 
 
 def test_city_staff_delete_user():
@@ -28,16 +30,16 @@ def test_city_staff_delete_user():
     user.supporting.add(models.Staff(city=city, category="supporter"))
     db.session.add(user)
     db.session.commit()
-    staffs = models.Staff.query.filter_by(city=city).all()
+    staffs = db.session.scalars(db.select(models.Staff).filter_by(city=city)).all()
     assert len(staffs) == 1
     assert staffs[0].staff == user
     assert staffs[0].city == city
 
     db.session.delete(user)
     db.session.commit()
-    assert models.Staff.query.count() == 0
-    assert models.City.query.count() == 1
+    assert query_count(models.Staff) == 0
+    assert query_count(models.City) == 1
     db.session.delete(site)
     db.session.commit()
     db.session.flush()
-    assert models.City.query.count() == 0
+    assert query_count(models.City) == 0

--- a/backend/tests/models/test_talks.py
+++ b/backend/tests/models/test_talks.py
@@ -2,6 +2,8 @@ from datetime import datetime
 
 from bamboo.database import db, models
 
+from .utils import query_count
+
 
 def test_talk_category():
     site = models.Site(name="Test site", config={})
@@ -11,14 +13,14 @@ def test_talk_category():
     talk.categories.add_all([keynote, act])
     db.session.add_all([site, keynote, act, talk])
     db.session.commit()
-    assert set(talk.categories.all()) == {
+    assert set(db.session.scalars(talk.categories.select()).all()) == {
         keynote,
         act,
     }
 
     db.session.delete(keynote)
     db.session.commit()
-    assert talk.categories.all() == [act]
+    assert db.session.scalars(talk.categories.select()).all() == [act]
 
 
 def test_talk_schedule():
@@ -35,6 +37,6 @@ def test_talk_schedule():
 
     db.session.delete(city)
     db.session.commit()
-    assert models.Venue.query.count() == 0
-    assert models.ScheduleItem.query.count() == 0
-    assert models.Talk.query.count() == 1
+    assert query_count(models.Venue) == 0
+    assert query_count(models.ScheduleItem) == 0
+    assert query_count(models.Talk) == 1

--- a/backend/tests/models/test_users.py
+++ b/backend/tests/models/test_users.py
@@ -27,6 +27,7 @@ def test_role():
     db.session.commit()
     assert user1.role == user2.role == role
     assert models.User.query.filter_by(role=role).all() == [user1, user2]
+    assert db.session.scalars(db.select(models.User).filter_by(role=role)).all() == [user1, user2]
 
 
 def test_staff():

--- a/backend/tests/models/utils.py
+++ b/backend/tests/models/utils.py
@@ -1,0 +1,6 @@
+import sqlalchemy as sa
+from bamboo.database import db
+
+
+def query_count(model):
+    return db.session.scalar(db.select(sa.func.count()).select_from(model))


### PR DESCRIPTION
`DynamicMapped` is considered legacy: https://docs.sqlalchemy.org/en/20/orm/large_collections.html#sqlalchemy.orm.DynamicMapped, use `WriteOnlyMapped` instead.