### PR TITLE
chore: use `pathlib` replace `os.path`

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,11 +1,12 @@
 import os
+from pathlib import Path
 
 from dotenv import load_dotenv
 
 from bamboo import create_app
 
-dotenv_path = os.path.join(os.path.dirname(__file__), ".env")
-if os.path.exists(dotenv_path):
+dotenv_path = Path(__file__).parent.resolve().joinpath(".env")
+if dotenv_path.exists():
     load_dotenv(dotenv_path)
 
 


### PR DESCRIPTION
Use `pathlib` to replace `os.path` to make code be more readable.